### PR TITLE
chore: remove experimental appDir config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig
+


### PR DESCRIPTION
## Summary
- remove experimental appDir option from Next.js config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6896311e8eb083209485b9cd9fd6a467