### PR TITLE
Fix image sizing in PostPreview

### DIFF
--- a/components/PostPreview.tsx
+++ b/components/PostPreview.tsx
@@ -5,7 +5,14 @@ import Image from "next/image";
 const PostPreview = (props: PostMetadata) => {
   return (
     <Link className="border border-slate-300 p-4 rounded-md drop-shadow-md hover:drop-shadow-xl bg-white" href={`posts/${props.slug}`}>
-        <Image className="min-w-full rounded-lg" src={`/images/${props.slug}.png`} width={500} height={0} alt={"Projects img"}/>
+        <Image
+          className="w-full rounded-lg"
+          src={`/images/${props.slug}.png`}
+          width={500}
+          height={300}
+          sizes="(max-width: 768px) 100vw, 500px"
+          alt="Projects img"
+        />
         <h2 className=" mt-2 text-black text-2xl hover:underline mb-4">{props.title}</h2>
         <p className=" p-botom-6 text-slate-700">{props.subtitle}</p>
         <p className="text-sm text-slate-400">{props.date}</p>


### PR DESCRIPTION
## Summary
- specify explicit height for preview images and make them responsive

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6896312c35388320b4e16f228a0b2cea